### PR TITLE
break out fapolicyd tracks

### DIFF
--- a/file-access-policy/02-verify/assignment.md
+++ b/file-access-policy/02-verify/assignment.md
@@ -1,0 +1,66 @@
+---
+slug: verify
+id: m3fknhr6o0jo
+type: challenge
+title: Verify the File Access Policy
+teaser: Verify the File Access Policy
+notes:
+- type: text
+  contents: Verify the File Access Policy
+tabs:
+- title: rhel
+  type: terminal
+  hostname: rhel
+- title: rhel Web Console
+  type: external
+  url: https://rhel.${_SANDBOX_ID}.instruqt.io:9090
+difficulty: basic
+timelimit: 4
+---
+Now that we've seen how the daemon is configured, let's see it in action.
+
+Switch to the user `rhel`.
+
+```bash
+su - rhel
+```
+
+Let's pull down a new application from an internet source, `cowsay`. There is nothing inherently malicious about this binary, though it provides a good example for our application control workflow.
+
+```bash
+curl -L -O https://github.com/Code-Hex/Neo-cowsay/releases/download/v2.0.4/cowsay_2.0.4_Linux_x86_64.tar.gz
+```
+Now, extract `cowsay` into the user's home directory.
+```
+tar xsf cowsay_2.0.4_Linux_x86_64.tar.gz
+```
+
+You should have no problems executing the `cowsay` binary:
+
+```bash
+./cowsay "mooooo"
+```
+
+Let's start up fapolicyd and see what happens:
+
+```bash
+sudo systemctl start fapolicyd
+```
+
+The password is `redhat`.
+
+```bash
+redhat
+```
+
+Now run the `cowsay` command again.
+
+```bash
+./cowsay "mooooo"
+```
+
+You'll obtain the following error.
+
+![opnotpermitted](../assets/opnotpermitted.png)
+
+Great! Because the `cowsay` binary isn't in the RPM database, or the file-backed trust database configured at `/etc/fapolicyd/fapolicyd.trust`, the execution is blocked.

--- a/file-access-policy/03-update/assignment.md
+++ b/file-access-policy/03-update/assignment.md
@@ -1,12 +1,12 @@
 ---
-slug: apply
-id: m3fknhr6o0jo
+slug: Update
+id: v3ftjsr1o2mn
 type: challenge
-title: Apply the File Access Policy
-teaser: Apply the File Access Policy
+title: Update the File Access Policy
+teaser: Update the File Access Policy
 notes:
 - type: text
-  contents: Apply the File Access Policy
+  contents: Update the File Access Policy
 tabs:
 - title: rhel
   type: terminal
@@ -15,49 +15,9 @@ tabs:
   type: external
   url: https://rhel.${_SANDBOX_ID}.instruqt.io:9090
 difficulty: basic
-timelimit: 10
+timelimit: 4
 ---
-Now that we've seen how the daemon is configured, let's see it in action.
-
-Switch to the user `rhel`.
-
-```bash
-su - rhel
-```
-
-In the user's home directory is a compiled binary, `cowsay`. There is nothing inherently malicious about this binary, though it provides a good example for our application control workflow.
-
-You should have no problems executing the `cowsay` binary:
-
-```bash
-./cowsay "mooooo"
-```
-
-Let's start up fapolicyd and see what happens:
-
-```bash
-sudo systemctl start fapolicyd
-```
-
-The password is `redhat`.
-
-```bash
-redhat
-```
-
-Now run the `cowsay` command again.
-
-```bash
-./cowsay "mooooo"
-```
-
-You'll obtain the following error.
-
-![opnotpermitted](../assets/opnotpermitted.png)
-
-Great! Because the `cowsay` binary isn't in the RPM database, or the file-backed trust database configured at `/etc/fapolicyd/fapolicyd.trust`, the execution is blocked.
-
-What if we know that this binary is trusted, and we want to allow it on the system? We have a couple of options:
+What if we know that the `cowsay` binary is trusted, and we want to allow it on the system? We have a couple of options:
 
 * We could create a RPM spec file for the binary, build an RPM, sign it, and install it into the RPM database
 * We can update the file-backed trust database

--- a/file-access-policy/04-explore/assignment.md
+++ b/file-access-policy/04-explore/assignment.md
@@ -1,0 +1,42 @@
+---
+slug: Explore
+id: g3asv34uy6ju
+type: challenge
+title: Explore fapolicyd integrity
+teaser: Explore fapolicyd integrity
+notes:
+- type: text
+  contents: Explore fapolicyd integrity
+tabs:
+- title: rhel
+  type: terminal
+  hostname: rhel
+- title: rhel Web Console
+  type: external
+  url: https://rhel.${_SANDBOX_ID}.instruqt.io:9090
+difficulty: basic
+timelimit: 4
+---
+Let's take a quick look at fapolicyd and integrity. The `more` command is installed via the RPM database, so it's trusted to execute on the system:
+
+```bash
+sudo rpm -qf /bin/more
+```
+
+What if the more command was substituted out for something malicious? First, let's verify that fapolicyd is still running:
+
+```bash
+sudo systemctl status fapolicyd
+```
+
+Now let's substitute the `more` command for the `cowsay` binary in our user's home directory:
+
+```bash
+sudo /bin/cp ./cowsay /bin/more
+```
+
+```bash
+/bin/more "mooooo"
+```
+
+Hmmmm. So by default, fapolicyd doesn't check what the file looks like, only where it is executing from. This means that an attacker could potentially hijack the execution path of a trusted file, and execute malicious code on behalf of a user.

--- a/file-access-policy/05-integritycontrols/assignment.md
+++ b/file-access-policy/05-integritycontrols/assignment.md
@@ -15,33 +15,9 @@ tabs:
   type: external
   url: https://rhel.${_SANDBOX_ID}.instruqt.io:9090
 difficulty: basic
-timelimit: 10
+timelimit: 4
 ---
-Let's take a quick look at fapolicyd and integrity. The `more` command is installed via the RPM database, so it's trusted to execute on the system:
-
-```bash
-sudo rpm -qf /bin/more
-```
-
-What if the more command was substituted out for something malicious? First, let's verify that fapolicyd is still running:
-
-```bash
-sudo systemctl status fapolicyd
-```
-
-Now let's substitute the `more` command for the `cowsay` binary in our user's home directory:
-
-```bash
-sudo /bin/cp ./cowsay /bin/more
-```
-
-```bash
-/bin/more "mooooo"
-```
-
-Hmmmm. So by default, fapolicyd doesn't check what the file looks like, only where it is executing from. This means that an attacker could potentially hijack the execution path of a trusted file, and execute malicious code on behalf of a user.
-
-To mitigate these scenarios, fapolicyd supports different types of file integrity:
+To mitigate situations where a trusted binary is substituted, fapolicyd supports different types of file integrity:
 
 * File-size checking - this is a very fast method of integrity checking, where fapolicyd verifies that the file is the correct size before allowing execution
 * Comparing SHA-256 hashes - computing and checking SHA-256 checksums is more secure than file-size checking, but does have an impact on system performance.

--- a/file-access-policy/track.yml
+++ b/file-access-policy/track.yml
@@ -21,6 +21,7 @@ icon: https://storage.googleapis.com/instruqt-frontend/img/tracks/default.png
 tags: []
 owner: rhel
 developers:
+- sboulden@redhat.com
 - myee@redhat.com
 private: false
 published: true

--- a/file-access-policy/track_scripts/setup-rhel
+++ b/file-access-policy/track_scripts/setup-rhel
@@ -18,8 +18,5 @@ usermod -aG wheel rhel
 echo "Setting password" >> /root/post-run.log
 echo redhat | passwd --stdin rhel
 
-echo "Adding cowsay" >> /root/post-run.log
-curl -L https://github.com/Code-Hex/Neo-cowsay/releases/download/v2.0.4/cowsay_2.0.4_Linux_x86_64.tar.gz | tar xvz -C /home/rhel
-
 echo "Fixing permissions" >> /root/post-run.log
 chown rhel:rhel /home/rhel/*


### PR DESCRIPTION
Breaks out the `fapolicyd` tracks and makes them smaller and more manageable. 

I tried to test this locally, but it doesn't look like I'm part of the rhel-labs Instruqt org. ie;
```
$ instruqt auth login
...
==> Setting Red Hat OpenShift as your default organization.
    Run instruqt config unset organization to undo.
```
And then when testing:
```
$ instruqt track test
==> Finding track by slug: rhel/file-access-policy
    [ERROR] Unauthorized
```