### PR TITLE
Remove permissions verification

### DIFF
--- a/file-access-policy/track_scripts/setup-rhel
+++ b/file-access-policy/track_scripts/setup-rhel
@@ -17,6 +17,3 @@ usermod -aG wheel rhel
 
 echo "Setting password" >> /root/post-run.log
 echo redhat | passwd --stdin rhel
-
-echo "Fixing permissions" >> /root/post-run.log
-chown rhel:rhel /home/rhel/*


### PR DESCRIPTION
Since we now allow the user to pull down the `cowsay` script during the `fapolicyd` lab, there's no requirement to validate permissions. This was also breaking the lab setup.