### PR TITLE
Update fapolicyd track image to RHEL 9.1

### DIFF
--- a/file-access-policy/config.yml
+++ b/file-access-policy/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: rhel
-  image: projects/tmm-instruqt-11-26-2021/global/images/rhel-9-0-06-13-2022-1
+  image: projects/tmm-instruqt-11-26-2021/global/images/rhel-9-1-11-18-2022-4
   shell: /bin/bash
   environment:
     TERM: xterm


### PR DESCRIPTION
I haven't tested this, as I don't think I have permissions to push track updates. 

I'll validate once this change is available in the lab.