### PR TITLE
ubi-init package not found in epel8 or 9

### DIFF
--- a/satellite-online/03-create-image/assignment.md
+++ b/satellite-online/03-create-image/assignment.md
@@ -86,7 +86,7 @@ We'll add some packages from custom repositories.
 Add packages from the custom repositories.
 
 1) Add the following packages.
-   - `ubi-init`
+   - `libyubikey`
    - `openvpn`
 
 2) Click `Next`.


### PR DESCRIPTION
Remove the ubi-init package reference, picked libyubikey

Related to #165, HMS lab for summit.

I don't have repo permissions to specify reviewers/assignees, @myee111 