### PR TITLE
removed cruft from startup scripts. rhel clients now use standard image.

### DIFF
--- a/satellite-basics-6-16/11-installsoftware/setup-rhel1
+++ b/satellite-basics-6-16/11-installsoftware/setup-rhel1
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dnf remove -y tmux

--- a/satellite-basics-6-16/11-installsoftware/setup-rhel2
+++ b/satellite-basics-6-16/11-installsoftware/setup-rhel2
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dnf remove -y tmux

--- a/satellite-basics-6-16/config.yml
+++ b/satellite-basics-6-16/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: rhel1
-  image: projects/tmm-instruqt-11-26-2021/global/images/satellite-lab-client1-10-07-24
+  image: projects/tmm-instruqt-11-26-2021/global/images/rhel-9-5-11-27-24
   shell: /bin/bash
   environment:
     TERM: xterm
@@ -11,7 +11,7 @@ virtualmachines:
   - https
   - high-ports
 - name: rhel2
-  image: projects/tmm-instruqt-11-26-2021/global/images/satellite-lab-client2-10-07-24
+  image: projects/tmm-instruqt-11-26-2021/global/images/rhel-9-5-11-27-24
   shell: /bin/bash
   environment:
     TERM: xterm
@@ -21,7 +21,7 @@ virtualmachines:
   - https
   - high-ports
 - name: satellite
-  image: projects/tmm-instruqt-11-26-2021/global/images/satellite-server-11-8-24
+  image: projects/tmm-instruqt-11-26-2021/global/images/satellite-server-11-27-24
   shell: /bin/bash
   environment:
     TERM: xterm

--- a/satellite-basics-6-16/track.yml
+++ b/satellite-basics-6-16/track.yml
@@ -37,5 +37,5 @@ lab_config:
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 50
-checksum: "13353184682461110387"
+checksum: "10221270388358660828"
 enhanced_loading: false

--- a/satellite-basics-6-16/track_scripts/setup-rhel1
+++ b/satellite-basics-6-16/track_scripts/setup-rhel1
@@ -6,22 +6,30 @@ until [ -f /opt/instruqt/bootstrap/host-bootstrap-completed ]; do
     sleep 1
 done
 
-#subscription-manager config --rhsm.manage_repos=1
-#subscription-manager register --activationkey=${ACTIVATION_KEY} --org=12451665 --force
+subscription-manager register --activationkey=${ACTIVATION_KEY} --org=12451665 --force
 
-useradd rhel
-usermod -aG wheel rhel
+dnf install wireguard-tools -y
 
-echo redhat | passwd --stdin rhel
+subscription-manager unregister
 
-timedatectl set-timezone America/New_York
+# Create a stock wg0.conf.
+cat <<EOT > /etc/wireguard/wg0.conf
+[Interface]
+Address = 192.0.2.2/24
+PrivateKey = qIicy0R6xdgMThB/3gWZ6ZUFS7WABBUkeGjc4bEPwl0=
+DNS = 192.0.2.1
 
-# Edit the wireguard if wg0 to point at satellite. Then create the interface with nmcli.
+[Peer]
+PublicKey = 1Y7yWRJZxLK3kKKwGLPffsSf/E2nw6mxHg+yvnfvOV4=
+AllowedIPs = 192.0.2.0/24
+Endpoint = 10.128.0.14:51820
+PersistentKeepalive = 20
+EOT
+
+# Edit the wireguard if wg0 to point at satellite's ip. Satellite's IP is dynamic. Then create the interface with nmcli.
 sed -i "/^Endpoint /s/=.*$/= satellite.${_SANDBOX_ID}.svc.cluster.local:51820/" /etc/wireguard/wg0.conf
-sed -i "s/Address =/#Address =/" /etc/wireguard/wg0.conf
-nmcli con mod wg0 ipv4.dns 192.0.2.1
-nmcli con up wg0
-wg syncconf wg0 /etc/wireguard/wg0.conf
+
+nmcli connection import type wireguard file /etc/wireguard/wg0.conf
 
 cat <<EOT >> /etc/systemd/system/wg-startup.service
 [Unit]

--- a/satellite-basics-6-16/track_scripts/setup-rhel2
+++ b/satellite-basics-6-16/track_scripts/setup-rhel2
@@ -6,22 +6,30 @@ until [ -f /opt/instruqt/bootstrap/host-bootstrap-completed ]; do
     sleep 1
 done
 
-#subscription-manager config --rhsm.manage_repos=1
-#subscription-manager register --activationkey=${ACTIVATION_KEY} --org=12451665 --force
+subscription-manager register --activationkey=${ACTIVATION_KEY} --org=12451665 --force
 
-useradd rhel
-usermod -aG wheel rhel
+dnf install wireguard-tools -y
 
-echo redhat | passwd --stdin rhel
+subscription-manager unregister
 
-timedatectl set-timezone America/New_York
+# Create a stock wg0.conf.
+cat <<EOT > /etc/wireguard/wg0.conf
+[Interface]
+Address = 192.0.2.3/24
+PrivateKey = 4MNE07Auu6f2L6ahmYoXB332H+lxQupBQjOP+aAX7UI=
+DNS = 192.0.2.1
+
+[Peer]
+PublicKey = 1Y7yWRJZxLK3kKKwGLPffsSf/E2nw6mxHg+yvnfvOV4=
+AllowedIPs = 192.0.2.0/24
+Endpoint = 10.128.0.14:51820
+PersistentKeepalive = 20
+EOT
 
 # Edit the wireguard if wg0 to point at satellite. Then create the interface with nmcli.
 sed -i "/^Endpoint /s/=.*$/= satellite.${_SANDBOX_ID}.svc.cluster.local:51820/" /etc/wireguard/wg0.conf
-sed -i "s/Address =/#Address =/" /etc/wireguard/wg0.conf
-nmcli con mod wg0 ipv4.dns 192.0.2.1
-nmcli con up wg0
-wg syncconf wg0 /etc/wireguard/wg0.conf
+
+nmcli connection import type wireguard file /etc/wireguard/wg0.conf
 
 cat <<EOT >> /etc/systemd/system/wg-startup.service
 [Unit]

--- a/satellite-basics-6-16/track_scripts/setup-satellite
+++ b/satellite-basics-6-16/track_scripts/setup-satellite
@@ -6,48 +6,15 @@ until [ -f /opt/instruqt/bootstrap/host-bootstrap-completed ]; do
     sleep 1
 done
 
-echo "Setup script for satellite"
-
-echo "Adding wheel" > /root/post-run.log
-useradd rhel
-usermod -aG wheel rhel
-
-echo "setting password" >> /root/post-run.log
-echo redhat | passwd --stdin rhel
-
-echo "DONE" >> /root/post-run.log
-
 echo "export LANG=en_US.UTF-8" >> /root/.bashrc
 
-rm -rf /home/myee/manifest_satellite-*
-
-# Add satellite.lab to hosts entry.
-sed -ie 's/svc.cluster.local/& satellite.lab/g' /etc/hosts
-
 # Add the following hosts to /etc/hosts
-cat <<EOT >> /etc/hosts
+cat <<EOT > /etc/hosts
 192.0.2.2   rhel1 rhel1.lab
 192.0.2.3   rhel2 rhel2.lab
 192.0.2.1   satellite.lab satellite
 192.0.2.4   satellite-2.lab satellite-2
 192.0.2.5   capsule.lab capsule
-EOT
-
-# Create wireguard config files
-# cat <<EOT > /etc/wireguard/satellite-server-template-1.private.key
-# ${WIREGUARD_SATELLITE_PRIVATE_KEY}
-# EOT
-
-# cat <<EOT > /etc/wireguard/satellite-server-template-1.public.key
-# ${WIREGUARD_SATELLITE_PUBLIC_KEY}
-# EOT
-
-cat <<EOT > /etc/wireguard/satellite-server-template-1.private.key
-6LXqhMZXv1vrZolWq2GpU5fCmDnFZgkBm6kkoCfIW3M=
-EOT
-
-cat <<EOT > /etc/wireguard/satellite-server-template-1.public.key
-1Y7yWRJZxLK3kKKwGLPffsSf/E2nw6mxHg+yvnfvOV4=
 EOT
 
 cat <<EOT > /etc/wireguard/wg0.conf
@@ -76,7 +43,6 @@ EOT
 
 # Bring up wireguard interface
 nmcli con import type wireguard file /etc/wireguard/wg0.conf
-nmcli con up wg0
 
-# dnsmasq is set to start up automatically. Since wg0 doesn't exist at startup, dnsmasq will error out since it's configured to do stuff with wg0.
-systemctl restart dnsmasq
+# dnsmasq is set to disabled. Since wg0 doesn't exist at startup, dnsmasq will error out since it's configured to do stuff with wg0.
+systemctl enable --now dnsmasq


### PR DESCRIPTION
Satellite Basics lab now uses standard rhel image. All the wireguard setup is in the setup scripts. 