### PR TITLE
Better way to set the image mode versions

### DIFF
--- a/image-mode-basics/01-create-an-image/assignment.md
+++ b/image-mode-basics/01-create-an-image/assignment.md
@@ -24,6 +24,7 @@ tabs:
   path: Containerfile
 difficulty: basic
 timelimit: 3000
+enhanced_loading: null
 ---
 
 Welcome to this lab experience for Red Hat Enterprise Linux.

--- a/image-mode-basics/02-deploy-an-image/assignment.md
+++ b/image-mode-basics/02-deploy-an-image/assignment.md
@@ -21,9 +21,10 @@ tabs:
   title: VM console
   type: terminal
   hostname: rhel
-  cmd: virsh console bootc
+  cmd: virsh console bootc-vm
 difficulty: basic
 timelimit: 1
+enhanced_loading: null
 ---
 Launch bootc-image-builder
 ===
@@ -41,7 +42,7 @@ There are several ways to deploy a bootc image to a host, depending on the targe
 podman run --rm --privileged \
         --volume .:/output \
          --volume ./config.json:/config.json \
-        registry.redhat.io/rhel9/bootc-image-builder:latest \
+        registry.redhat.io/rhel9/bootc-image-builder:[[ Instruqt-Var key="BOOTC_RHEL_VERSION" hostname="rhel" ]] \
         --type qcow2 \
         --config config.json \
          [[ Instruqt-Var key="CONTAINER_REGISTRY_ENDPOINT" hostname="rhel" ]]/test-bootc
@@ -55,14 +56,14 @@ Prepare and run the bootc image
 To launch a KVM guest, copy the QCOW2 disk image we created to the default libvirt storage pool.
 
 ```bash,run
-cp qcow2/disk.qcow2 /var/lib/libvirt/images/bootc-vm.qcow2
+cp qcow2/disk.qcow2 /var/lib/libvirt/images/bootc[[ Instruqt-Var key="BOOTC_RHEL_VERSION" hostname="rhel" ]]-vm.qcow2
 ```
 
 Using `virt-install` we can define a simple VM and import the new disk image.
 
 ```bash,run
-virt-install --name bootc \
- --disk /var/lib/libvirt/images/bootc-vm.qcow2 \
+virt-install --name bootc-vm \
+--disk /var/lib/libvirt/images/bootc[[ Instruqt-Var key="BOOTC_RHEL_VERSION" hostname="rhel" ]]-vm.qcow2 \
 --import \
 --memory 2048 \
 --graphics none \
@@ -74,7 +75,7 @@ virt-install --name bootc \
 Once the VM has been defined, we can start it.
 
 ```bash,run
-virsh start bootc
+virsh start bootc-vm
 ```
 
 Attach to the console of the VM running our bootc image

--- a/image-mode-basics/03-add-software-to-image/assignment.md
+++ b/image-mode-basics/03-add-software-to-image/assignment.md
@@ -22,13 +22,9 @@ tabs:
   type: code
   hostname: rhel
   path: Containerfile
-- id: knueqzeeypop
-  title: VM console
-  type: terminal
-  hostname: rhel
-  cmd: virsh console bootc
 difficulty: basic
 timelimit: 600
+enhanced_loading: null
 ---
 
 Click on the [button label="Containerfile" background="#ee0000" color="#c7c7c7"](tab-1) tab.

--- a/image-mode-basics/04-apply-image/assignment.md
+++ b/image-mode-basics/04-apply-image/assignment.md
@@ -17,17 +17,13 @@ tabs:
   title: Terminal
   type: terminal
   hostname: rhel
-- id: pzj6sgp9ncuu
-  title: Containerfile
-  type: code
-  hostname: rhel
-  path: Containerfile
 - id: yr6lhrue8afd
   title: VM console
   type: terminal
   hostname: rhel
-  cmd: virsh console bootc
+  cmd: virsh console bootc-vm
 difficulty: ""
+enhanced_loading: null
 ---
 Exploring system status
 ===
@@ -41,7 +37,7 @@ The `bootc` command is what controls the state of the running host and the avail
 
 The `spec` section provides the information about the image in use and where `bootc` is looking for it. Our host is pulling from a container registry.
 ```bash,run
-sudo bootc status | grep spec: -A 10
+sudo bootc status | grep spec: -A 4
 ```
 
 The `staged` section provides information about what's been pulled down to disk for the next boot. Since we just did a fresh install, this is null at the moment.

--- a/image-mode-basics/track.yml
+++ b/image-mode-basics/track.yml
@@ -18,10 +18,8 @@ developers:
 - myee@redhat.com
 show_timer: true
 lab_config:
-  overlay: false
-  width: 33
-  position: right
   feedback_recap_enabled: true
+  feedback_tab_enabled: false
   loadingMessages: true
   theme:
     name: original
@@ -29,4 +27,5 @@ lab_config:
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 33
-checksum: "760900542313485442"
+checksum: "9483646692229430784"
+enhanced_loading: false

--- a/image-mode-basics/track_scripts/setup-rhel
+++ b/image-mode-basics/track_scripts/setup-rhel
@@ -1,11 +1,14 @@
 #!/bin/bash
+set -euxo pipefail
 
 subscription-manager config --rhsm.manage_repos=1
 subscription-manager register --activationkey=${ACTIVATION_KEY} --org=12451665 --force
 
 # Log into terms based registry and stage bootc and bib images
+BOOTC_RHEL_VER=9.4
+agent variable set BOOTC_RHEL_VERSION $BOOTC_RHEL_VER
 podman login -u='1979710|rhel-tmm' -p=${REG_SVC_ACCT} registry.redhat.io
-podman pull registry.redhat.io/rhel9/rhel-bootc:latest registry.redhat.io/rhel9/bootc-image-builder:latest
+podman pull registry.redhat.io/rhel9/rhel-bootc:$BOOTC_RHEL_VER registry.redhat.io/rhel9/bootc-image-builder:$BOOTC_RHEL_VER
 
 # Some shortcuts for users
 # reglogin - uses podman secret to log into the terms based registry in case creds time out or initial pull fails
@@ -28,7 +31,7 @@ dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarc
 dnf install -y certbot
 
 # stop the process that is using TCP port 80; we need that port open for certbot
-fuser -k 80/tcp
+# fuser -k 80/tcp
 
 # request certificates
 certbot certonly --standalone --preferred-challenges http -d ${HOSTNAME}.${INSTRUQT_PARTICIPANT_ID}.instruqt.io --non-interactive --agree-tos -m trackbot@instruqt.com -v
@@ -159,7 +162,7 @@ EOF
 
 # create basic bootc containerfile
 cat <<EOF> Containerfile
-FROM registry.redhat.io/rhel9/rhel-bootc
+FROM registry.redhat.io/rhel9/rhel-bootc:$BOOTC_RHEL_VER
 
 ADD etc /etc
 

--- a/image-mode-day2/02-switch-an-image/assignment.md
+++ b/image-mode-day2/02-switch-an-image/assignment.md
@@ -34,15 +34,15 @@ enhanced_loading: null
 A word about tags
 ===
 
-To this point, we've been letting podman automatically create tags for the images we've built. As a review, the naming convention for container images is `registry/name:tag`. We've been setting the registry and name in the command line, which means all of the tags are set to `latest` by default.
+To this point, we've been letting podman automatically create tags for the images we've built. As a review, the naming convention for container images is `registry/name:tag`.
 
-If you look at all of the images available in the lab, you'll see most of them have `latest` in the tag column. The `docker.io/library/registry` image is the only one that has a unique tag that tries to convey some information via it's tag.
+If you look at all of the images available in the lab, you'll see most of them have a version number in the tag column. The image we've built is the only one that uses `latest`, which signals the most recent build and is auto-generated if you don't specify a tag.
 
 ```bash,run
 podman images
 ```
 
-While this is convenient, it can create a lot of confusion. Which `latest` was really created last? What in that `latest` container? Which updates did we provide? Have you seen the `latest` tag in any of the `bootc status` output so far?
+While this is convenient, it can create a lot of confusion. What in that `latest` container? Which updates did we provide? Have you seen the `latest` tag in any of the `bootc status` output so far?
 
 
 Using tags for identifying image contents

--- a/image-mode-day2/03-rollback-a-host/assignment.md
+++ b/image-mode-day2/03-rollback-a-host/assignment.md
@@ -17,11 +17,6 @@ tabs:
   title: Terminal
   type: terminal
   hostname: rhel
-- id: tpkjptwwk0eu
-  title: Containerfile
-  type: code
-  hostname: rhel
-  path: Containerfile
 - id: fzmfm00uw2yp
   title: VM console
   type: terminal

--- a/image-mode-day2/track.yml
+++ b/image-mode-day2/track.yml
@@ -27,5 +27,5 @@ lab_config:
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 33
-checksum: "9200472003432348126"
+checksum: "3198179653936879206"
 enhanced_loading: false

--- a/image-mode-day2/track_scripts/setup-rhel
+++ b/image-mode-day2/track_scripts/setup-rhel
@@ -5,8 +5,11 @@ subscription-manager config --rhsm.manage_repos=1
 subscription-manager register --activationkey=${ACTIVATION_KEY} --org=12451665 --force
 
 # Log into terms based registry and stage bootc and bib images
+BOOTC_RHEL_VER=9.4
+agent variable set BOOTC_RHEL_VERSION $BOOTC_RHEL_VER
+
 podman login -u='1979710|rhel-tmm' -p=${REG_SVC_ACCT} registry.redhat.io
-podman pull registry.redhat.io/rhel9/rhel-bootc:latest registry.redhat.io/rhel9/bootc-image-builder:latest
+podman pull registry.redhat.io/rhel9/rhel-bootc:$BOOTC_RHEL_VER registry.redhat.io/rhel9/bootc-image-builder:$BOOTC_RHEL_VER
 
 # Some shortcuts for users
 # reglogin - uses podman secret to log into the terms based registry in case creds time out or initial pull fails
@@ -83,7 +86,7 @@ EOF
 
 # create updated bootc containerfile from image-mode-basics
 cat <<EOF> Containerfile
-FROM registry.redhat.io/rhel9/rhel-bootc
+FROM registry.redhat.io/rhel9/rhel-bootc:$BOOTC_RHEL_VER
 
 ADD etc /etc
 
@@ -94,7 +97,7 @@ EOF
 
 # create V3 index.html relocated containerfile
 cat <<EOM> Containerfile.index
-FROM registry.redhat.io/rhel9/rhel-bootc
+FROM registry.redhat.io/rhel9/rhel-bootc:$BOOTC_RHEL_VER
 
 ADD etc /etc
 


### PR DESCRIPTION
This supercedes #599 and fixes #600 

Refactor the approach to setting the image mode version used using variables instead of manual editing. Made some room for automating the day2 VM build in the near future.

A few random Instruqt settings get updated based on new defaults.