### PR TITLE
Add a helper script to work with track pull .remote files

### DIFF
--- a/track_diff.sh
+++ b/track_diff.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+for i in $(find . -name "*.remote")
+do
+  diff -Nau $i $(dirname $i)\/$(basename $i .remote)
+  if [ $? -eq 0 ]
+  then 
+    echo $i same, removing
+    rm $i
+  fi
+done


### PR DESCRIPTION
The `instruqt` command doesn't currently do diffs when a track is pulled and we aren't using the GitHub beta integration, so comparing the remote files created by `instruqt track pull` to the local branch is manual and tedious.

This script will compare all of the .remote files found with their local versions. It prints the diff if there is a difference, otherwise it removes the file.

Sample run

```
╭╢ X  mmicene  ~  Projects   …   instruqt  image-mode-basics  mmicene-600+*  
╰╴instruqt track pull
==> Finding track by slug: rhel/image-mode-basics 
    [ERROR] Track has both remote and local changes
    
    Writing remote track to '*.remote' files, please update your local track before pushing. Either:
    1) Use `instruqt track pull --force` to overwrite your local changes, or
    2) Resolve the differences yourself using your favorite diff tool and editor.
    
    Writing track:
image-mode-basics
├── 01-create-an-image
│   ├── assignment.md.remote
│   └── check-rhel.remote
├── 02-deploy-an-image
│   └── assignment.md.remote
├── 03-add-software-to-image
│   ├── assignment.md.remote
│   └── check-rhel.remote
├── 04-apply-image
│   └── assignment.md.remote
├── track_scripts
│   ├── cleanup-rhel
│   └── setup-rhel
├── config.yml.remote
└── track.yml.remote
    OK
╭╢ X  mmicene  ~  Projects   …   instruqt  image-mode-basics  mmicene-600+*  
╰╴find . -name "*.remote"
./01-create-an-image/assignment.md.remote
./01-create-an-image/check-rhel.remote
./02-deploy-an-image/assignment.md.remote
./03-add-software-to-image/check-rhel.remote
./03-add-software-to-image/assignment.md.remote
./04-apply-image/assignment.md.remote
./track.yml.remote
./config.yml.remote
╭╢ X  mmicene  ~  Projects   …   instruqt  image-mode-basics  mmicene-600+*  
╰╴../instruqt_diff.sh 
--- ./01-create-an-image/assignment.md.remote	2024-12-10 13:56:41.559614672 -0500
+++ ./01-create-an-image/assignment.md	2024-12-10 13:14:41.737971729 -0500
@@ -29,10 +29,12 @@
 
 Welcome to this lab experience for Red Hat Enterprise Linux.
 
-The system displayed beside this text is a Red Hat Enterprise Linux 9
-system registered with Subscription Manager.
+The system displayed beside this text is a Red Hat Enterprise Linux 9 system registered with Subscription Manager.
 
-Image mode uses standard container tools to define, build, and transport bootc images. Podman has already been installed on this host as a build environment, along with some additional files.
+Image mode uses standard container tools to define, build, and transport bootc images. Podman has already been installed on this host as a build environment, along with some additional files and required images. If you see an error related to authentication like the one below, you can use the `reglogin` command provided to log into the Red Hat Container Registry and re-run the command.
+```
+unable to retrieve auth token: invalid username/password: unauthorized: Please login to the Red Hat Registry using your Customer Portal credentials.
+```
 
 Examine the containerfile
 ===
./01-create-an-image/check-rhel.remote same, removing
./02-deploy-an-image/assignment.md.remote same, removing
./03-add-software-to-image/check-rhel.remote same, removing
./03-add-software-to-image/assignment.md.remote same, removing
./04-apply-image/assignment.md.remote same, removing
--- ./track.yml.remote	2024-12-10 13:56:41.559614672 -0500
+++ ./track.yml	2024-12-10 11:54:27.999348968 -0500
@@ -27,5 +27,5 @@
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 33
-checksum: "13024264225583185968"
+checksum: "9483646692229430784"
 enhanced_loading: false
./config.yml.remote same, removing
╭╢ X  mmicene  ~  Projects   …   instruqt  image-mode-basics  mmicene-600+*  
╰╴find . -name "*.remote"
./01-create-an-image/assignment.md.remote
./track.yml.remote
```

It's best to run it inside a track directory, there's not a huge number of guardrails at the moment.