### PR TITLE
Small fixes to command-line-assistant setup

### DIFF
--- a/command-line-assistant/01-demo/setup-rhel
+++ b/command-line-assistant/01-demo/setup-rhel
@@ -4,7 +4,15 @@ dnf copr enable -y @rhel-lightspeed/command-line-assistant
 
 dnf install -y `agent variable get cla_version`
 
+# Change endpoint
+sed -i 's/endpoint = .*/endpoint = "http:\/\/localhost:8000"/' /etc/xdg/command-line-assistant/config.toml
+
+# Disable ssl verification
+sed -i 's/verify_ssl = .*/verify_ssl = false/' /etc/xdg/command-line-assistant/config.toml
+
+# Run the RLSAPI container
 podman run -d -e WATSONX_APIKEY=${WATSONX_API_KEY} \
 	-e WATSONX_PROJECT_ID="a74348df-2d24-4f95-b623-37bda7cff0d1" \
 	-e USE_RAG=false \
-	quay.io/redhat-user-workloads/rhel-lightspeed-tenant/rlsapi/rlsapi:latest 
+	-p 8000:8000 \
+	quay.io/redhat-user-workloads/rhel-lightspeed-tenant/rlsapi/rlsapi:latest


### PR DESCRIPTION
* Expose the port 8000 to be accessible
* Turn ssl verification off
* Change endpoint to localhost:8000