### PR TITLE
Move basics to SSH

### DIFF
--- a/image-mode-basics/01-create-an-image/assignment.md
+++ b/image-mode-basics/01-create-an-image/assignment.md
@@ -77,8 +77,6 @@ Image mode uses OCI standard container tools to build bootc images, like any oth
 ```bash,run
 podman build -t [[ Instruqt-Var key="CONTAINER_REGISTRY_ENDPOINT" hostname="rhel" ]]/test-bootc .
 ```
->[!NOTE]
-> You may see a few informational warnings during the build process, these do not affect the install, but are side effects of a containerized install.
 
 Once built, bootc images use OCI standard container registries for distribution. We are using a simple registry in this lab, but enterprise registries will provide ways to inspect contents, history, manage tags and more.
 

--- a/image-mode-basics/02-deploy-an-image/assignment.md
+++ b/image-mode-basics/02-deploy-an-image/assignment.md
@@ -18,10 +18,10 @@ tabs:
   type: terminal
   hostname: rhel
 - id: artmeele676g
-  title: VM console
+  title: VM SSH session
   type: terminal
   hostname: rhel
-  cmd: virsh console bootc-vm
+  cmd: ssh core@bootc-vm
 difficulty: basic
 timelimit: 1
 enhanced_loading: null
@@ -36,21 +36,23 @@ To boot this image as a host, we install it to the filesystem using `bootc`. But
 There are several ways to deploy a bootc image to a host, depending on the target environment. For the purposes of this lab, we'll create a QCOW2 image to be run on a KVM virtual machine. To build the QCOW2 image we'll use a tool called `bootc-image-builder`.
 
 > [!NOTE]
-> This operation will take 5 minutes to complete.
+> This operation will take about 4 minutes to complete.
 
 ```bash,run
 podman run --rm --privileged \
         --volume .:/output \
         --volume ./config.json:/config.json \
         --volume /var/lib/containers/storage:/var/lib/containers/storage \
-        registry.redhat.io/rhel9/bootc-image-builder:latest \
+        registry.redhat.io/rhel9/bootc-image-builder:9.5 \
         --local \
         --type qcow2 \
         --config config.json \
          [[ Instruqt-Var key="CONTAINER_REGISTRY_ENDPOINT" hostname="rhel" ]]/test-bootc
 ```
 
-This tool is a containerized version of image builder that includes the `bootc` tooling to unpack the container image contents to the virtual disk. Supported output formats include AMIs and VMDKs. For bare metal, we can use Anaconda with `bootc` support to install to physical disk. Other typical ways we'd install a RHEL host, like over PXE or HTTP Boot are also available to us. Using the `--local` option and adding the system container storage path as a volume allows `bootc-image-builder` to use the image directly from disk. You can also pull the image from the remote registry by omitting these lines.
+This tool is a containerized version of image builder that includes the `bootc` tooling to unpack the container image contents to the virtual disk. Supported output formats include AMIs and VMDKs. For bare metal, we can use Anaconda with `bootc` support to install to physical disk. Other typical ways we'd install a RHEL host, like over PXE or HTTP Boot are also available to us.
+
+Using the `--local` option and adding the system container storage path as a volume allows `bootc-image-builder` to use the image directly from disk. You can also pull the image from the remote registry by omitting these lines.
 
 Prepare and run the bootc image
 ===
@@ -80,26 +82,17 @@ Once the VM has been defined, we can start it.
 virsh start bootc-vm
 ```
 
-Attach to the console of the VM running our bootc image
+SSH to the VM running our bootc image
 ===
 
-Next, attach to the console. Switch to the [button label="VM console" background="#ee0000" color="#c7c7c7"](tab-1) tab.
+Next, log into the VM. Switch to the [button label="VM SSH session" background="#ee0000" color="#c7c7c7"](tab-1) tab.
 
 > [!NOTE]
-> If the console hasn't connected or there is an error, you can reconnect by clicking Refresh next to the tab name. The prompt will look like this. ![](../assets/terminal_prompt.png)
-
-Check the VM is running the applications we installed
-===
+> If the SSH session hasn't connected or there is an error, you can reconnect by clicking Refresh next to the tab name. The prompt will look like this. ![](../assets/terminal_prompt.png)
 
 Once the system has finished booting, you can log in with the following credentials. These were injected by `bootc-image-builder` when creating the disk image. There are several ways to handle user creation and authentication methods, customizing the disk image with `bootc-image-builder` is just one.
 
-In the [button label="VM console" background="#ee0000" color="#c7c7c7"](tab-1) tab, log into the vm with the following credentials.
-
-Username:
-
-```bash,run
-core
-```
+Log into the vm with the following credentials.
 
 Password:
 

--- a/image-mode-basics/04-apply-image/assignment.md
+++ b/image-mode-basics/04-apply-image/assignment.md
@@ -18,20 +18,28 @@ tabs:
   type: terminal
   hostname: rhel
 - id: yr6lhrue8afd
-  title: VM console
+  title: VM SSH session
   type: terminal
   hostname: rhel
-  cmd: virsh console bootc-vm
+  cmd: ssh core@bootc-vm
 difficulty: ""
 enhanced_loading: null
 ---
 Exploring system status
 ===
 
-Click on the [button label="VM console" background="#ee0000" color="#c7c7c7"](tab-2) tab.
+Click on the [button label="VM SSH session" background="#ee0000" color="#c7c7c7"](tab-2) tab.
 
 > [!NOTE]
-> You may need to tap `enter` to wake up the console, you should still be logged in as `core`
+> If the SSH session hasn't connected or there is an error, you can reconnect by clicking Refresh next to the tab name. The prompt will look like this. ![](../assets/terminal_prompt.png)
+
+Log into the vm with the following credentials.
+
+Password:
+
+```bash,run
+redhat
+```
 
 The `bootc` command is what controls the state of the running host and the available images on disk. This is how we get the current state, if updates are available, change roles, and more. The `bootc status` command is how we explore that state.
 
@@ -72,14 +80,14 @@ With the updated image available in the registry, let's see if `bootc` detects i
 ```bash,run
 sudo bootc upgrade --check
 ```
-> [!NOTE]
-> Since we are attached to the console and not a login session, you may see some errors. These are system logs that can be ignored
 
 Since `bootc` tracks the image as listed in the `spec`, we see updates as soon as they hit the registry. We are shown some details about what changes will be made, like the SHA and version. Let's go ahead and stage this update for use.
 
 ```bash,run
 sudo bootc upgrade
 ```
+
+Notice how the update is pulled in layers. This is based on the contents of the container image we built. Since our `vim` install created a fairly sizable change, we need to pull in a large update.
 
 Exploring system status
 ===
@@ -109,11 +117,8 @@ sudo reboot
 ```
 Once the system has completed rebooting, you can log in with the new credentials. Since this user's credentials are stored in `/etc`, the new password will be in effect.
 
-Username:
-
-```bash,run
-core
-```
+> [!NOTE]
+> Remember to reconnect by clicking Refresh next to the tab name. The prompt will look like this. ![](../assets/terminal_prompt.png)
 
 Password:
 

--- a/image-mode-basics/04-apply-image/assignment.md
+++ b/image-mode-basics/04-apply-image/assignment.md
@@ -33,7 +33,7 @@ Click on the [button label="VM console" background="#ee0000" color="#c7c7c7"](ta
 > [!NOTE]
 > You may need to tap `enter` to wake up the console, you should still be logged in as `core`
 
-The `bootc` command is what controls the state of the running host and the available images on disk. This is how we get the current state, if updates are available, change roles, and more. The `bootc status` command is how we explore that state. 
+The `bootc` command is what controls the state of the running host and the available images on disk. This is how we get the current state, if updates are available, change roles, and more. The `bootc status` command is how we explore that state.
 
 ```bash,run
 sudo bootc status
@@ -42,7 +42,7 @@ sudo bootc status
 You can see the booted image, and if there are any staged or rollback images on the host. The name, version, and digest for each image are listed in this base view. We'll talk more about what that means later.
 
 > [!TIP]
->The `bootc` command will detect if we pass the output to a pipe and automatically output the full status details in YAML. You can control that ouput by passing the `--format` option with either YAML or JSON arguments to get your preferred output. 
+>The `bootc` command will detect if we pass the output to a pipe and automatically output the full status details in YAML. You can control that ouput by passing the `--format` option with either YAML or JSON arguments to get your preferred output.
 
 Let's explore the detailed output section by section using `grep` to focus on certain parts. The `spec` section provides the information about the image in use and where `bootc` is looking for it. Our host is pulling from a container registry.
 ```bash,run

--- a/image-mode-basics/config.yml
+++ b/image-mode-basics/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: rhel
-  image: projects/tmm-instruqt-11-26-2021/global/images/virt-rhel-9-4-06-04-24
+  image: projects/tmm-instruqt-11-26-2021/global/images/virt-rhel-9-5-11-29-24
   shell: /bin/bash
   environment:
     TERM: xterm

--- a/image-mode-basics/track.yml
+++ b/image-mode-basics/track.yml
@@ -27,5 +27,5 @@ lab_config:
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 33
-checksum: "12257190661660022036"
+checksum: "3877338820631431515"
 enhanced_loading: false

--- a/image-mode-basics/track.yml
+++ b/image-mode-basics/track.yml
@@ -27,5 +27,5 @@ lab_config:
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 33
-checksum: "9483646692229430784"
+checksum: "12257190661660022036"
 enhanced_loading: false

--- a/image-mode-basics/track_scripts/setup-rhel
+++ b/image-mode-basics/track_scripts/setup-rhel
@@ -5,7 +5,8 @@ subscription-manager config --rhsm.manage_repos=1
 subscription-manager register --activationkey=${ACTIVATION_KEY} --org=12451665 --force
 
 # Log into terms based registry and stage bootc and bib images
-BOOTC_RHEL_VER=9.4
+dnf -y install podman skopeo
+BOOTC_RHEL_VER=9.5
 agent variable set BOOTC_RHEL_VERSION $BOOTC_RHEL_VER
 podman login -u='1979710|rhel-tmm' -p=${REG_SVC_ACCT} registry.redhat.io
 podman pull registry.redhat.io/rhel9/rhel-bootc:$BOOTC_RHEL_VER registry.redhat.io/rhel9/bootc-image-builder:$BOOTC_RHEL_VER

--- a/image-mode-day2/01-switch-registries/assignment.md
+++ b/image-mode-day2/01-switch-registries/assignment.md
@@ -91,7 +91,7 @@ sudo bootc switch [[ Instruqt-Var key="CONTAINER_REGISTRY_ENDPOINT" hostname="rh
 
 At first glance, `bootc switch` doesn't look very different from `bootc upgrade`. It will download and prepare the new image to a local deployment location on disk. It downloads any layers it detects are different based on the metadata available in the registry.
 
-We can see in the output of `bootc switch` that our new image has been queued to be activated the next time the host boots. We can also see if there are any changes waiting by checking `bootc status`. 
+We can see in the output of `bootc switch` that our new image has been queued to be activated the next time the host boots. We can also see if there are any changes waiting by checking `bootc status`.
 
 ```bash,run
 sudo bootc status

--- a/image-mode-day2/config.yml
+++ b/image-mode-day2/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: rhel
-  image: projects/tmm-instruqt-11-26-2021/global/images/image-mode-3-virt-rhel-9-4-10-11-24
+  image: projects/tmm-instruqt-11-26-2021/global/images/image-mode-virt-rhel-9-5-11-29-24
   shell: /bin/bash
   environment:
     TERM: xterm

--- a/image-mode-day2/track.yml
+++ b/image-mode-day2/track.yml
@@ -27,5 +27,5 @@ lab_config:
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 33
-checksum: "3198179653936879206"
+checksum: "6223407641552369681"
 enhanced_loading: false

--- a/image-mode-day2/track_scripts/setup-rhel
+++ b/image-mode-day2/track_scripts/setup-rhel
@@ -5,7 +5,7 @@ subscription-manager config --rhsm.manage_repos=1
 subscription-manager register --activationkey=${ACTIVATION_KEY} --org=12451665 --force
 
 # Log into terms based registry and stage bootc and bib images
-BOOTC_RHEL_VER=9.4
+BOOTC_RHEL_VER=9.5
 agent variable set BOOTC_RHEL_VERSION $BOOTC_RHEL_VER
 
 podman login -u='1979710|rhel-tmm' -p=${REG_SVC_ACCT} registry.redhat.io
@@ -30,7 +30,7 @@ echo redhat | passwd --stdin rhel
 
 # Start the target VM, created from the image-mode-basics lab image and maintained in the GCP compute image for this lab
 
-virsh start bootc
+virsh start bootc2
 
 # set up SSL for fully functioning registry
 # Enable EPEL for RHEL 9
@@ -114,7 +114,7 @@ RUN echo "New application coming soon!" > /usr/share/www/html/index.html
 
 EOM
 
-
+podman rmi rhel.pdnis0xkcq.instruqt.io:5000/test-bootc
 podman build -t ${HOSTNAME}.${INSTRUQT_PARTICIPANT_ID}.instruqt.io:5000/test-bootc .
 podman push ${HOSTNAME}.${INSTRUQT_PARTICIPANT_ID}.instruqt.io:5000/test-bootc
 


### PR DESCRIPTION
Move image-mode-basics to SSH access from VM console for cleaner user experience

Carrys some minor updates to image-mode-day2 prep pulled in from Instruqt sync