### PR TITLE
Cleanup the CLA lab

### DIFF
--- a/command-line-assistant/01-demo/setup-rhel
+++ b/command-line-assistant/01-demo/setup-rhel
@@ -1,18 +1,6 @@
 #!/bin/bash
-dnf install -y python3-pip container-tools tcsh
+dnf install -y tcsh
+
 dnf copr enable -y @rhel-lightspeed/command-line-assistant
 
 dnf install -y `agent variable get cla_version`
-
-# Change endpoint
-sed -i 's/endpoint = .*/endpoint = "http:\/\/localhost:8000"/' /etc/xdg/command-line-assistant/config.toml
-
-# Disable ssl verification
-sed -i 's/verify_ssl = .*/verify_ssl = false/' /etc/xdg/command-line-assistant/config.toml
-
-# Run the RLSAPI container
-podman run -d -e WATSONX_APIKEY=${WATSONX_API_KEY} \
-	-e WATSONX_PROJECT_ID="a74348df-2d24-4f95-b623-37bda7cff0d1" \
-	-e USE_RAG=false \
-	-p 8000:8000 \
-	quay.io/redhat-user-workloads/rhel-lightspeed-tenant/rlsapi/rlsapi:latest

--- a/command-line-assistant/config.yml
+++ b/command-line-assistant/config.yml
@@ -11,4 +11,3 @@ virtualmachines:
   provision_ssl_certificate: true
 secrets:
 - name: ACTIVATION_KEY
-- name: WATSONX_API_KEY


### PR DESCRIPTION
With the current achievement of running our backend infrastructure in production, we can now cleanup the lab and use a plain RHEL registered host for it.