### PR TITLE
Satellite Advanced lab - Remove katello-agent references

### DIFF
--- a/satellite-advanced-topics-6-17/02-image-mode/assignment.md
+++ b/satellite-advanced-topics-6-17/02-image-mode/assignment.md
@@ -305,3 +305,9 @@ bootc status
 ![](../assets/updatedbootcstatus.png)
 
 You can now see that the image mode host `rhel2` is now running our updated image labelled `satellite.lab/acme_org/bootc/rhel10beta:summit-2025` and you'll also see that you can roll back to the previous image if required.
+
+_Optional_: To see the updated information in the web UI, you can manually update facts from the `rhel2` host:
+
+```bash,run
+subscription-manager facts --update
+```

--- a/satellite-advanced-topics-6-17/04-rex-pull-mode/assignment.md
+++ b/satellite-advanced-topics-6-17/04-rex-pull-mode/assignment.md
@@ -40,9 +40,7 @@ Here are the configuration considerations:
 
 1. Port 1883 (MQTT) must be opened on the Satellite server running the Capsule service to allow incoming requests to subscribe to REX pull notifications, and the host must be allowed to connect to the Capsule server on port 443 (HTTPS) to enable REX pull mode.
 2. Capsule servers (and Capsule services) must be configured to support either REX SSH mode or REX pull mode. You cannot configure a Capsule to support both REX modes.
-3. For existing hosts running the katello agent, you can migrate to REX pull mode by installing the katello-pull-transport-migrate package. Documentation is provided at the bottom of this post. The katello agent has been deprecated as of Satellite 6.7.
-
-Katello Agent is removed from Satellite 6.17.
+3. For existing, registered hosts, you can migrate to REX pull mode by installing the katello-pull-transport-migrate package. Documentation is provided at the bottom of this post.
 
 Register the host rhel1 to the Satellite server
 ===


### PR DESCRIPTION
also a small optional step added to the Image mode challenge.